### PR TITLE
Track json as a dependency and ref it directly

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30,7 +30,7 @@ github.authenticate({
   token: process.env.FORKED_TOKEN
 });
 
-var meta = (0, _githubUrlParse2.default)(_shelljs2.default.exec('cat package.json | json repository.url').stdout);
+var meta = (0, _githubUrlParse2.default)(_shelljs2.default.exec('cat package.json | ./node_modules/json/lib/json.js repository.url').stdout);
 
 var index = meta.repo.indexOf('.git');
 if (index !== -1) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -30,7 +30,27 @@ github.authenticate({
   token: process.env.FORKED_TOKEN
 });
 
-var meta = (0, _githubUrlParse2.default)(_shelljs2.default.exec('cat package.json | json repository.url').stdout);
+var packageJson = _shelljs2.default.cat('package.json');
+
+if (!packageJson) {
+  throw new Error('I couldn’t find a package.json file in this directory.');
+}
+
+var parsedPackage = void 0,
+    repositoryUrl = void 0;
+
+try {
+  parsedPackage = JSON.parse(packageJson);
+  repositoryUrl = parsedPackage.repository ? parsedPackage.repository.url : null;
+} catch (e) {
+  throw new Error('Looks like package.json couldn’t be parsed.');
+}
+
+if (!repositoryUrl) {
+  throw new Error('Looks like package.json doesn’t have a repository url.');
+}
+
+var meta = (0, _githubUrlParse2.default)(repositoryUrl);
 
 var index = meta.repo.indexOf('.git');
 if (index !== -1) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -30,7 +30,7 @@ github.authenticate({
   token: process.env.FORKED_TOKEN
 });
 
-var meta = (0, _githubUrlParse2.default)(_shelljs2.default.exec('cat package.json | ./node_modules/json/lib/json.js repository.url').stdout);
+var meta = (0, _githubUrlParse2.default)(_shelljs2.default.exec('cat package.json | json repository.url').stdout);
 
 var index = meta.repo.indexOf('.git');
 if (index !== -1) {

--- a/index.js
+++ b/index.js
@@ -18,8 +18,26 @@ github.authenticate({
     token: process.env.FORKED_TOKEN,
 })
 
+const packageJson = shell.cat('package.json')
 
-const meta = parser(shell.exec('cat package.json | json repository.url').stdout)
+if (!packageJson) {
+  throw new Error('I couldn’t find a package.json file in this directory.')
+}
+
+let parsedPackage, repositoryUrl
+
+try {
+  parsedPackage = JSON.parse(packageJson)
+  repositoryUrl = parsedPackage.repository ? parsedPackage.repository.url : null
+} catch (e) {
+  throw new Error('Looks like package.json couldn’t be parsed.')
+}
+
+if (!repositoryUrl) {
+  throw new Error('Looks like package.json doesn’t have a repository url.')
+}
+
+const meta = parser(repositoryUrl)
 
 const index = meta.repo.indexOf('.git')
 if (index !== -1) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "github": "^0.2.4",
     "github-url-parse": "^0.1.0",
+    "json": "^9.0.3",
     "rimraf": "^2.5.2",
     "shelljs": "^0.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "github": "^0.2.4",
     "github-url-parse": "^0.1.0",
-    "json": "^9.0.3",
     "rimraf": "^2.5.2",
     "shelljs": "^0.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "forked",
   "version": "0.0.11",
   "description": "fork from the command line",
-  "main": "dist/main.js",
+  "main": "dist/index.js",
   "repository": {
     "type": "git",
     "url": "http://github.com/eanplatter/forked"


### PR DESCRIPTION
Fixes #2. Instead of `cat package.json | json repository.url` do `cat package.json | ./node_module/json/lib/json.js repository.url`.
