### PR TITLE
Support for supplied dependency name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15,6 +15,10 @@ var _githubUrlParse2 = _interopRequireDefault(_githubUrlParse);
 
 var _fs = require('fs');
 
+var _path = require('path');
+
+var _path2 = _interopRequireDefault(_path);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var github = new _github2.default({
@@ -33,7 +37,6 @@ github.authenticate({
 });
 
 var args = process.argv.slice(2);
-
 var packageJson = _shelljs2.default.cat(packagePath(args[0]));
 
 if (!packageJson) {
@@ -75,11 +78,13 @@ github.repos.fork({
 function packagePath(dep) {
   var cwd = process.cwd().match(/.*\/([^\/]+)/)[1];
   if (!dep || cwd == dep) {
-    return './package.json';
+    return 'package.json';
   }
 
-  var pathsToTry = ['./' + dep + '/package.json', './node_modules/' + dep + '/package.json'];
+  var pathsToTry = [_path2.default.resolve(dep, 'package.json'), _path2.default.resolve('node_modules', dep, 'package.json')];
+
   var pathToReturn = void 0;
+
   var packageFound = pathsToTry.some(function (path) {
     pathToReturn = path;
     try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,7 +38,7 @@ github.authenticate({
 
 var args = process.argv.slice(2);
 if (args.indexOf('-h') !== -1 || args.indexOf('--help') !== -1) {
-  console.log('  Easy-peasy usage:\n    1. Navigate to directory of dependency you want to fork.\n    2. run `fork`\n\n  Lemon-squeezy usage:\n    1. From your project’s root directory, run `fork dependencyName`.');
+  console.log('  Easy-peasy usage:\n    1. Navigate to directory of dependency you want to fork:\n      `cd project/node_modules/dependencyName`\n    2. Run: `fork`\n\n  Lemon-squeezy usage:\n    1. From anywhere, run: `fork path/to/dependency`.');
   process.exit();
 }
 var packageJson = _shelljs2.default.cat(packagePath(args[0]));

--- a/dist/index.js
+++ b/dist/index.js
@@ -76,7 +76,7 @@ github.repos.fork({
 });
 
 function packagePath(dep) {
-  var cwd = process.cwd().match(/.*\/([^\/]+)/)[1];
+  var cwd = process.cwd().match(/([^\/\\]+$)/)[1];
   if (!dep || cwd == dep) {
     return 'package.json';
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -80,27 +80,8 @@ github.repos.fork({
 });
 
 function packagePath(dep) {
-  var cwd = process.cwd().match(/([^\/\\]+$)/)[1];
-  if (!dep || cwd == dep) {
+  if (!dep) {
     return 'package.json';
   }
-
-  var pathsToTry = [_path2.default.resolve(dep, 'package.json'), _path2.default.resolve('node_modules', dep, 'package.json')];
-
-  var pathToReturn = void 0;
-
-  var packageFound = pathsToTry.some(function (path) {
-    pathToReturn = path;
-    try {
-      return (0, _fs.statSync)(path).isFile();
-    } catch (e) {
-      return false;
-    }
-  });
-
-  if (packageFound) {
-    return pathToReturn;
-  }
-
-  throw Error('I couldn’t find the ' + dep + ' dependency.');
+  return _path2.default.resolve(dep, 'package.json');
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -37,7 +37,7 @@ github.authenticate({
 });
 
 var args = process.argv.slice(2);
-if (args[0] == '-h') {
+if (args.indexOf('-h') !== -1 || args.indexOf('--help') !== -1) {
   console.log('  Easy-peasy usage:\n    1. Navigate to directory of dependency you want to fork.\n    2. run `fork`\n\n  Lemon-squeezy usage:\n    1. From your project’s root directory, run `fork dependencyName`.');
   process.exit();
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -37,6 +37,10 @@ github.authenticate({
 });
 
 var args = process.argv.slice(2);
+if (args[0] == '-h') {
+  console.log('  Easy-peasy usage:\n    1. Navigate to directory of dependency you want to fork.\n    2. run `fork`\n\n  Lemon-squeezy usage:\n    1. From your project’s root directory, run `fork dependencyName`.');
+  process.exit();
+}
 var packageJson = _shelljs2.default.cat(packagePath(args[0]));
 
 if (!packageJson) {

--- a/index.js
+++ b/index.js
@@ -68,28 +68,6 @@ github.repos.fork({
 })
 
 function packagePath (dep) {
-  const cwd = process.cwd().match(/([^\/\\]+$)/)[1]
-  if (!dep || cwd === dep) { return 'package.json' }
-
-  let pathsToTry = [
-    path.resolve(dep, 'package.json'),
-    path.resolve('node_modules', dep, 'package.json') ]
-
-  let pathToReturn
-
-  let packageFound = pathsToTry.some(path => {
-    pathToReturn = path
-    try {
-      return statSync(path).isFile()
-    }
-    catch (e) {
-      return false
-    }
-  })
-
-  if (packageFound) {
-    return pathToReturn
-  }
-
-  throw Error(`I couldn’t find the ${dep} dependency.`)
+  if (!dep) { return 'package.json' }
+  return path.resolve(dep, 'package.json')
 }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ github.authenticate({
 })
 
 const args = process.argv.slice(2)
-if (args[0] == '-h') {
+if (args.indexOf('-h') !== -1 || args.indexOf('--help') !== -1) {
   console.log(`  Easy-peasy usage:
     1. Navigate to directory of dependency you want to fork.
     2. run \`fork\`

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ github.repos.fork({
 })
 
 function packagePath (dep) {
-  const cwd = process.cwd().match(/.*\/([^\/]+)/)[1]
+  const cwd = process.cwd().match(/([^\/\\]+$)/)[1]
   if (!dep || cwd == dep) { return 'package.json' }
 
   let pathsToTry = [

--- a/index.js
+++ b/index.js
@@ -21,6 +21,15 @@ github.authenticate({
 })
 
 const args = process.argv.slice(2)
+if (args[0] == '-h') {
+  console.log(`  Easy-peasy usage:
+    1. Navigate to directory of dependency you want to fork.
+    2. run \`fork\`
+
+  Lemon-squeezy usage:
+    1. From your project’s root directory, run \`fork dependencyName\`.`)
+  process.exit()
+}
 const packageJson = shell.cat(packagePath(args[0]))
 
 if (!packageJson) {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import shell from 'shelljs'
 import GitHubApi from 'github'
 import parser from 'github-url-parse'
 import {statSync} from 'fs'
+import path from 'path'
 
 const github = new GitHubApi({
     version: '3.0.0',
@@ -59,9 +60,12 @@ github.repos.fork({
 
 function packagePath (dep) {
   const cwd = process.cwd().match(/.*\/([^\/]+)/)[1]
-  if (!dep || cwd == dep) { return './package.json' }
+  if (!dep || cwd == dep) { return 'package.json' }
 
-  let pathsToTry = [ `./${dep}/package.json`, `./node_modules/${dep}/package.json` ]
+  let pathsToTry = [
+    path.resolve(dep, 'package.json'),
+    path.resolve('node_modules', dep, 'package.json') ]
+
   let pathToReturn
 
   let packageFound = pathsToTry.some(path => {

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ github.repos.fork({
 
 function packagePath (dep) {
   const cwd = process.cwd().match(/([^\/\\]+$)/)[1]
-  if (!dep || cwd == dep) { return 'package.json' }
+  if (!dep || cwd === dep) { return 'package.json' }
 
   let pathsToTry = [
     path.resolve(dep, 'package.json'),

--- a/index.js
+++ b/index.js
@@ -23,11 +23,12 @@ github.authenticate({
 const args = process.argv.slice(2)
 if (args.indexOf('-h') !== -1 || args.indexOf('--help') !== -1) {
   console.log(`  Easy-peasy usage:
-    1. Navigate to directory of dependency you want to fork.
-    2. run \`fork\`
+    1. Navigate to directory of dependency you want to fork:
+      \`cd project/node_modules/dependencyName\`
+    2. Run: \`fork\`
 
   Lemon-squeezy usage:
-    1. From your project’s root directory, run \`fork dependencyName\`.`)
+    1. From anywhere, run: \`fork path/to/dependency\`.`)
   process.exit()
 }
 const packageJson = shell.cat(packagePath(args[0]))


### PR DESCRIPTION
Add support for supplying a dependency name — `fork dep`, which will perform the following checks:
1. If `cwd == dep`, try to fork from current directory; if not…
2. If `./dep/package.json` exists, try to fork from that directory; if not…
3. If `./node_modules/dep/package.json` exists, try to fork from that directory; if not, throw an error.

As discussed in #4.
